### PR TITLE
Cluster labels

### DIFF
--- a/R/extract_assignment.R
+++ b/R/extract_assignment.R
@@ -34,6 +34,8 @@ extract_cluster_assignment.KMeansCluster <- function(object, ...) {
 # ------------------------------------------------------------------------------
 
 cluster_assignment_tibble <- function(clusters, n_clusters) {
-  res <- factor(clusters, levels = seq_len(n_clusters))
+  res <- factor(clusters,
+                levels = unique(clusters),
+                labels = paste0("Clust", 1:n_clusters))
   tibble::tibble(.cluster = res)
 }

--- a/R/extract_assignment.R
+++ b/R/extract_assignment.R
@@ -34,8 +34,7 @@ extract_cluster_assignment.KMeansCluster <- function(object, ...) {
 # ------------------------------------------------------------------------------
 
 cluster_assignment_tibble <- function(clusters, n_clusters) {
-  res <- factor(clusters,
-                levels = unique(clusters),
-                labels = paste0("Clust", 1:n_clusters))
+  orig_labels <- unique(clusters)
+  res <- relabel_clusters(clusters, orig_labels, n_clusters)
   tibble::tibble(.cluster = res)
 }

--- a/R/predict_helpers.R
+++ b/R/predict_helpers.R
@@ -1,12 +1,23 @@
 stats_kmeans_predict <- function(object, new_data) {
-  clusters <- apply(flexclust::dist2(object$centers, new_data), 2, which.min)
+  orig_labels_ordered <- unique(object$cluster)  # reorder centers
+  centroids <- object$centers
+  clusters <- apply(flexclust::dist2(centroids, new_data), 2, which.min)
 
+  relabel_clusters(clusters, orig_labels_ordered, nrow(centroids))
 }
 
 clusterR_kmeans_predict <- function(object, new_data) {
-  res <- apply(flexclust::dist2(object$centroids, new_data), 2, which.min)
-  factor(res, levels = seq_along(object$obs_per_cluster))
+  orig_labels_ordered <- unique(object$clusters)
+  centroids <- object$centroids  # reorder centers
+  clusters <- apply(flexclust::dist2(centroids, new_data), 2, which.min)
+
+  relabel_clusters(clusters, orig_labels_ordered, nrow(centroids))
 }
 
+relabel_clusters <- function(clusters, orig_labels_ordered, n_clusters) {
 
-### I need the original cluster labels to line up with the new ones
+  factor(clusters,
+         levels = orig_labels_ordered,
+         labels = paste0("Cluster_", 1:n_clusters))
+
+}

--- a/R/predict_helpers.R
+++ b/R/predict_helpers.R
@@ -1,9 +1,12 @@
 stats_kmeans_predict <- function(object, new_data) {
-  res <- apply(flexclust::dist2(object$centers, new_data), 2, which.min)
-  factor(res, levels = seq_along(object$size))
+  clusters <- apply(flexclust::dist2(object$centers, new_data), 2, which.min)
+
 }
 
 clusterR_kmeans_predict <- function(object, new_data) {
   res <- apply(flexclust::dist2(object$centroids, new_data), 2, which.min)
   factor(res, levels = seq_along(object$obs_per_cluster))
 }
+
+
+### I need the original cluster labels to line up with the new ones

--- a/tests/testthat/test-k_means.R
+++ b/tests/testthat/test-k_means.R
@@ -68,20 +68,22 @@ ref_predictions <- ref_res$centers %>%
   apply(2, which.min) %>%
   unname()
 
-expect_equal(
-  ref_predictions,
-  predict(kmeans_fit, mtcars)$.pred_cluster %>% as.numeric()
-)
-
-expect_equal(
-  unname(ref_res$cluster),
-  extract_cluster_assignment(kmeans_fit)$.cluster %>% as.numeric()
-)
-
-expect_equal(
-  predict(kmeans_fit, mtcars)$.pred_cluster %>% as.numeric(),
-  extract_cluster_assignment(kmeans_fit)$.cluster %>% as.numeric()
-)
+# replaced with test in test-predict_formats.R
+# should check that clusterings are "essentially equivalent"
+# expect_equal(
+#   ref_predictions,
+#   predict(kmeans_fit, mtcars)$.pred_cluster %>% as.numeric()
+# )
+#
+# expect_equal(
+#   unname(ref_res$cluster),
+#   extract_cluster_assignment(kmeans_fit)$.cluster %>% as.numeric()
+# )
+#
+# expect_equal(
+#   predict(kmeans_fit, mtcars)$.pred_cluster %>% as.numeric(),
+#   extract_cluster_assignment(kmeans_fit)$.cluster %>% as.numeric()
+# )
 
 # ------------------------------------------------------------------------------
 

--- a/tests/testthat/test-predict_formats.R
+++ b/tests/testthat/test-predict_formats.R
@@ -5,15 +5,44 @@ library(dplyr)
 
 # ------------------------------------------------------------------------------
 
-kmeans_fit <-
+kmeans_fit_stats <-
   k_means(k = 3, mode = "partition") %>%
   set_engine_celery("stats") %>%
   fit(~ ., data = mtcars)
 
+
+kmeans_fit_cR <-
+  k_means(k = 3, mode = "partition") %>%
+  set_engine_celery("ClusterR") %>%
+  fit(~ ., data = mtcars)
+
 # ------------------------------------------------------------------------------
 
-test_that('regression predictions', {
-  expect_true(is_tibble(predict(kmeans_fit, new_data = mtcars)))
-  expect_true(is.factor(celery:::predict_cluster.cluster_fit(kmeans_fit, new_data = mtcars)))
-  expect_equal(names(predict(kmeans_fit, new_data = mtcars)), ".pred_cluster")
+test_that('kmeans predictions', {
+  expect_true(is_tibble(predict(kmeans_fit_stats, new_data = mtcars)))
+  expect_true(is.factor(celery:::predict_cluster.cluster_fit(kmeans_fit_stats, new_data = mtcars)))
+  expect_equal(names(predict(kmeans_fit_stats, new_data = mtcars)), ".pred_cluster")
 })
+
+test_that('predictions match original assignments', {
+
+  expect_equal(predict(kmeans_fit_stats, new_data = mtcars)$.pred_cluster,
+               unname(extract_cluster_assignment(kmeans_fit_stats)$.cluster))
+
+  expect_equal(predict(kmeans_fit_cR, new_data = mtcars)$.pred_cluster,
+               unname(extract_cluster_assignment(kmeans_fit_cR)$.cluster))
+
+})
+
+
+test_that('cluster assignments are named right', {
+
+  preds_stats <- extract_cluster_assignment(kmeans_fit_stats)$.cluster
+  expect_equal(as.character(unique(preds_stats)), levels(preds_stats))
+
+  preds_CR <- extract_cluster_assignment(kmeans_fit_cR)$.cluster
+  expect_equal(as.character(unique(preds_CR)), levels(preds_CR))
+
+  expect_equal(as.character(preds_stats[1]), "Cluster_1")
+})
+


### PR DESCRIPTION
This is some work on getting the cluster labelling to be consistent and consistently ordered.  ("Clust1", "Clust2", etc.)

The challenge right now is that `predict()` type functions reference the centroids from the fitted model, which correspond in order to the original cluster numbers.  However, without the full data, we can't match the original cluster to the new names.

I'm working on solving this, just getting the branch up and running.